### PR TITLE
Refactor archetecture for creation from rdkit

### DIFF
--- a/src/stereomolgraph/graph2rdmol.py
+++ b/src/stereomolgraph/graph2rdmol.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from typing import TypeAlias
 
 import rdkit.Chem as Chem  # type: ignore
 
 from stereomolgraph.algorithms._bond_orders import connectivity2bond_orders
+from stereomolgraph.graphs.crg import CondensedReactionGraph
+from stereomolgraph.graphs.mg import AtomId, MolGraph
+from stereomolgraph.graphs.scrg import StereoCondensedReactionGraph
+from stereomolgraph.graphs.smg import StereoMolGraph
 from stereomolgraph.periodic_table import SYMBOLS
 from stereomolgraph.stereodescriptors import (
     AtropBond,
@@ -17,11 +21,7 @@ from stereomolgraph.stereodescriptors import (
     TrigonalBipyramidal,
 )
 
-if TYPE_CHECKING:
-    from stereomolgraph.graphs.crg import CondensedReactionGraph
-    from stereomolgraph.graphs.mg import AtomId, MolGraph, RDKitAtomId
-    from stereomolgraph.graphs.smg import StereoMolGraph
-
+RDKitAtomId: TypeAlias = int
 
 bond_type_dict = {
     0.5: Chem.BondType.HYDROGEN,
@@ -431,3 +431,109 @@ def set_crg_bond_orders(
             mol.GetBondBetweenAtoms(a1, a2).SetBondType(bond_type_dict[bond_order])
 
     return mol
+
+
+def condensed_reaction_graph_to_rdmol(
+    graph: CondensedReactionGraph,
+    generate_bond_orders: bool = False,
+    allow_charged_fragments: bool = False,
+    charge: int = 0,
+) -> tuple[Chem.rdchem.RWMol, dict[RDKitAtomId, AtomId]]:
+    """Convert a CondensedReactionGraph to an RDKit molecule.
+
+    :param graph: CondensedReactionGraph to convert
+    :param generate_bond_orders: If True, compute bond orders for the CRG
+    :param allow_charged_fragments: If True, allow charged fragments
+    :param charge: Total charge of the molecule
+    :return: RDKit molecule and index-to-atom-id mapping
+    """
+    mol, idx_map_num_dict = mol_graph_to_rdmol(
+        graph=graph,
+        generate_bond_orders=False,
+        allow_charged_fragments=allow_charged_fragments,
+        charge=0,
+    )
+
+    if generate_bond_orders:
+        mol = set_crg_bond_orders(
+            graph=graph,
+            mol=mol,
+            idx_map_num_dict=idx_map_num_dict,
+            generate_bond_orders=generate_bond_orders,
+            allow_charged_fragments=allow_charged_fragments,
+            charge=charge,
+        )
+
+    return mol, idx_map_num_dict
+
+
+def stereo_condensed_reaction_graph_to_rdmol(
+    graph: StereoCondensedReactionGraph,
+    generate_bond_orders: bool = False,
+    allow_charged_fragments: bool = False,
+    charge: int = 0,
+) -> tuple[Chem.rdchem.RWMol, dict[RDKitAtomId, AtomId]]:
+    """Convert a StereoCondensedReactionGraph to an RDKit molecule.
+
+    The stereo changes are merged into a flat StereoMolGraph which is then
+    converted via :func:`stereo_mol_graph_to_rdmol`.
+
+    :param graph: StereoCondensedReactionGraph to convert
+    :param generate_bond_orders: If True, compute bond orders for the SCRG
+    :param allow_charged_fragments: If True, allow charged fragments
+    :param charge: Total charge of the molecule
+    :return: RDKit molecule and index-to-atom-id mapping
+    """
+    from stereomolgraph.graphs.crg import Change
+    from stereomolgraph.graphs.smg import StereoMolGraph
+
+    ts_smg = StereoMolGraph(graph)  # bond change is now just a bond
+
+    for _atom, stereo_change_dict in graph.atom_stereo_changes.items():
+        atom_stereo = next(
+            (
+                stereo
+                for stereo_change in (
+                    Change.FLEETING,
+                    Change.BROKEN,
+                    Change.FORMED,
+                )
+                if (stereo := stereo_change_dict[stereo_change]) is not None
+            ),
+            None,
+        )
+        if atom_stereo:
+            ts_smg.set_atom_stereo(atom_stereo)
+
+    for _bond, stereo_change_dict in graph.bond_stereo_changes.items():
+        bond_stereo = next(
+            (
+                stereo
+                for stereo_change in (
+                    Change.FLEETING,
+                    Change.BROKEN,
+                    Change.FORMED,
+                )
+                if (stereo := stereo_change_dict[stereo_change]) is not None
+            ),
+            None,
+        )
+        if bond_stereo:
+            ts_smg.set_bond_stereo(bond_stereo)
+
+    mol, idx_map_num_dict = stereo_mol_graph_to_rdmol(
+        ts_smg,
+        generate_bond_orders=False,
+        allow_charged_fragments=allow_charged_fragments,
+        charge=charge,
+    )
+    if generate_bond_orders:
+        mol = set_crg_bond_orders(
+            graph=graph,
+            mol=mol,
+            generate_bond_orders=generate_bond_orders,
+            allow_charged_fragments=allow_charged_fragments,
+            charge=charge,
+            idx_map_num_dict=idx_map_num_dict,
+        )
+    return mol, idx_map_num_dict

--- a/src/stereomolgraph/graphs/__init__.py
+++ b/src/stereomolgraph/graphs/__init__.py
@@ -4,41 +4,16 @@ CondensedReactionGraph and StereoCondensedReactionGraph"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+__all__ = (
+    "AtomId",
+    "Bond",
+    "MolGraph",
+    "StereoMolGraph",
+    "CondensedReactionGraph",
+    "StereoCondensedReactionGraph",
+)
 
-if TYPE_CHECKING:
-    from stereomolgraph.graphs.crg import CondensedReactionGraph
-    from stereomolgraph.graphs.mg import AtomId, Bond, MolGraph
-    from stereomolgraph.graphs.scrg import StereoCondensedReactionGraph
-    from stereomolgraph.graphs.smg import StereoMolGraph
-
-
-def __getattr__(name: str):
-    match name:
-        case "AtomId":
-            from stereomolgraph.graphs.mg import AtomId
-
-            return AtomId
-        case "Bond":
-            from stereomolgraph.graphs.mg import Bond
-
-            return Bond
-        case "MolGraph":
-            from stereomolgraph.graphs.mg import MolGraph
-
-            return MolGraph
-        case "StereoMolGraph":
-            from stereomolgraph.graphs.smg import StereoMolGraph
-
-            return StereoMolGraph
-        case "CondensedReactionGraph":
-            from stereomolgraph.graphs.crg import CondensedReactionGraph
-
-            return CondensedReactionGraph
-        case "StereoCondensedReactionGraph":
-            from stereomolgraph.graphs.scrg import StereoCondensedReactionGraph
-
-            return StereoCondensedReactionGraph
-
-        case _:
-            raise AttributeError(f"module has no attribute {name}")
+from stereomolgraph.graphs.crg import Change, CondensedReactionGraph
+from stereomolgraph.graphs.mg import AtomId, Bond, MolGraph
+from stereomolgraph.graphs.scrg import StereoCondensedReactionGraph
+from stereomolgraph.graphs.smg import StereoMolGraph

--- a/src/stereomolgraph/graphs/crg.py
+++ b/src/stereomolgraph/graphs/crg.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from typing_extensions import override
+
 from stereomolgraph.algorithms.circular import (
     color_refine_crg,
     label_hash,
@@ -10,7 +12,6 @@ from stereomolgraph.algorithms.circular import (
 )
 from stereomolgraph.algorithms.isomorphism import vf2pp_all_isomorphisms
 from stereomolgraph.coords import BondsFromDistance
-from stereomolgraph.graph2rdmol import mol_graph_to_rdmol, set_crg_bond_orders
 from stereomolgraph.graphs.mg import Bond, MolGraph
 
 if TYPE_CHECKING:
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from stereomolgraph.coords import GeometryProtocol
-    from stereomolgraph.graphs.mg import AtomId, RDKitAtomId
 
 
 class Change(Enum):
@@ -47,16 +47,19 @@ class CondensedReactionGraph(MolGraph):
 
     __hash__ = MolGraph.__hash__
 
+    @override
     def _compute_colors(self) -> np.ndarray:
         labels = label_hash(self, atom_labels=("atom_type", "reaction"))
         return color_refine_crg(self, atom_labels=labels)
 
+    @override
     def _compute_hash(self) -> int:
         if self.n_atoms == 0:
             return hash(self.__class__)
         else:
             return int(numpy_int_multiset_hash(self._get_colors()))
 
+    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return NotImplemented
@@ -75,6 +78,7 @@ class CondensedReactionGraph(MolGraph):
             )
         )
 
+    @override
     def add_bond(self, atom1: int, atom2: int, **attr: Any):
         """
         Adds a bond between atom1 and atom2.
@@ -86,6 +90,7 @@ class CondensedReactionGraph(MolGraph):
             raise TypeError("reaction bond has to have reaction attribute")
         super().add_bond(atom1, atom2, **attr)
 
+    @override
     def set_bond_attribute(self, atom1: int, atom2: int, attr: str, value: Any):
         """
         sets the Attribute of the bond between Atom1 and Atom2.
@@ -196,31 +201,7 @@ class CondensedReactionGraph(MolGraph):
                 active_atoms.update(self._neighbors[atom])
         return active_atoms
 
-    def _to_rdmol(
-        self,
-        generate_bond_orders: bool = False,
-        allow_charged_fragments: bool = False,
-        charge: int = 0,
-    ) -> tuple[Chem.rdchem.RWMol, dict[RDKitAtomId, AtomId]]:
-        mol, idx_map_num_dict = mol_graph_to_rdmol(
-            graph=self,
-            generate_bond_orders=False,
-            allow_charged_fragments=allow_charged_fragments,
-            charge=0,
-        )
-
-        if generate_bond_orders:
-            mol = set_crg_bond_orders(
-                graph=self,
-                mol=mol,
-                idx_map_num_dict=idx_map_num_dict,
-                generate_bond_orders=generate_bond_orders,
-                allow_charged_fragments=allow_charged_fragments,
-                charge=charge,
-            )
-
-        return mol, idx_map_num_dict
-
+    @override
     def to_rdmol(
         self,
         generate_bond_orders: bool = False,

--- a/src/stereomolgraph/graphs/mg.py
+++ b/src/stereomolgraph/graphs/mg.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Collection
+from collections.abc import (
+    Collection,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from copy import deepcopy
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import Any, Optional, TypeAlias
 
 import numpy as np
+from rdkit import Chem  # type: ignore
+from typing_extensions import Self
 
 from stereomolgraph.algorithms.circular import (
     color_refine_mg,
@@ -14,32 +21,11 @@ from stereomolgraph.algorithms.circular import (
     numpy_int_multiset_hash,
 )
 from stereomolgraph.algorithms.isomorphism import vf2pp_all_isomorphisms
-from stereomolgraph.coords import BondsFromDistance
-from stereomolgraph.graph2rdmol import mol_graph_to_rdmol
+from stereomolgraph.coords import BondsFromDistance, GeometryProtocol
 from stereomolgraph.periodic_table import PERIODIC_TABLE, SYMBOLS, Element
 from stereomolgraph.xyz2graph import connectivity_from_geometry
 
-if TYPE_CHECKING:
-    from collections.abc import (
-        Collection,
-        Iterable,
-        Mapping,
-        Sequence,
-    )
-    from typing import Any, Optional, Self, TypeAlias, TypeVar
-
-    from rdkit import Chem  # type: ignore
-
-    from stereomolgraph.coords import GeometryProtocol
-
-    N = TypeVar(
-        "N",
-        bound=int,
-    )
-
 AtomId: TypeAlias = int
-
-RDKitAtomId: TypeAlias = int
 
 Bond: TypeAlias = frozenset[AtomId]
 
@@ -462,26 +448,16 @@ class MolGraph:
             matrix[atomid_index_dict[a2]][atomid_index_dict[a1]] = 1
         return matrix
 
-    def _to_rdmol(
-        self,
-        generate_bond_orders: bool = False,
-        allow_charged_fragments: bool = False,
-        charge: int = 0,
-    ) -> tuple[Chem.rdchem.RWMol, dict[RDKitAtomId, AtomId]]:
-        return mol_graph_to_rdmol(
-            self,
-            generate_bond_orders=generate_bond_orders,
-            allow_charged_fragments=allow_charged_fragments,
-            charge=charge,
-        )
-
     def to_rdmol(
         self,
         generate_bond_orders: bool = True,
         allow_charged_fragments: bool = False,
         charge: int = 0,
     ) -> Chem.rdchem.Mol:
-        mol, _ = self._to_rdmol(
+        from stereomolgraph.graph2rdmol import mol_graph_to_rdmol
+
+        mol, _ = mol_graph_to_rdmol(
+            self,
             generate_bond_orders=generate_bond_orders,
             allow_charged_fragments=allow_charged_fragments,
             charge=charge,
@@ -491,7 +467,7 @@ class MolGraph:
         return mol
 
     @classmethod
-    def from_rdmol(cls, rdmol: Chem.Mol, use_atom_map_number: bool = False) -> Self:
+    def from_rdmol(cls, rdmol: Chem.Mol) -> Self:
         """
         Creates a StereoMolGraph from an RDKit Mol object.
         Implicit Hydrogens are added to the graph.
@@ -503,13 +479,11 @@ class MolGraph:
         the substituents.
 
         :param rdmol: RDKit Mol object
-        :param use_atom_map_number: If the atom map number should be used
-                                    instead of the atom index
         :return: StereoMolGraph
         """
         from stereomolgraph.rdmol2graph import mol_graph_from_rdmol
 
-        mg = mol_graph_from_rdmol(cls, rdmol, use_atom_map_number=use_atom_map_number)
+        mg = mol_graph_from_rdmol(cls, rdmol)
         assert isinstance(mg, cls), "MolGraph.from_rdmol did not return a MolGraph"
         return mg
 

--- a/src/stereomolgraph/graphs/scrg.py
+++ b/src/stereomolgraph/graphs/scrg.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import sys
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Generic
+from typing import Generic, Optional
+
+from typing_extensions import Self, TypeVar, override
 
 from stereomolgraph.algorithms.circular import (
     color_refine_scrg,
@@ -13,8 +14,7 @@ from stereomolgraph.algorithms.circular import (
     numpy_int_multiset_hash,
 )
 from stereomolgraph.algorithms.isomorphism import vf2pp_all_isomorphisms
-from stereomolgraph.coords import BondsFromDistance
-from stereomolgraph.graph2rdmol import set_crg_bond_orders
+from stereomolgraph.coords import BondsFromDistance, GeometryProtocol
 from stereomolgraph.graphs.crg import Change, CondensedReactionGraph
 from stereomolgraph.graphs.mg import AtomId, Bond, MolGraph
 from stereomolgraph.graphs.smg import StereoMolGraph
@@ -27,23 +27,7 @@ from stereomolgraph.xyz2graph import (
     stero_from_geometry,
 )
 
-if TYPE_CHECKING:
-    import sys
-    from collections.abc import Iterable, Mapping
-    from typing import Optional
-
-    from rdkit import Chem
-
-    from stereomolgraph.coords import GeometryProtocol
-    from stereomolgraph.graphs.mg import AtomId, RDKitAtomId
-
-# Self is included in typing from 3.11
-if sys.version_info >= (3, 11):
-    from typing import Self, TypeVar
-else:
-    from typing_extensions import Self, TypeVar
-
-S = TypeVar("S", bound="Stereo", contravariant=True)
+S = TypeVar("S", bound="Stereo")
 
 
 class ChangeDict(dict[Change, None | S], Generic[S]):
@@ -66,6 +50,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
     __hash__ = MolGraph.__hash__
 
+    @override
     def __init__(self, mol_graph: Optional[MolGraph] = None):
         super().__init__(mol_graph)
         self._atom_stereo_change = defaultdict(ChangeDict[AtomStereo])
@@ -75,15 +60,18 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
             self._atom_stereo_change.update(mol_graph._atom_stereo_change)
             self._bond_stereo_change.update(mol_graph._bond_stereo_change)
 
+    @override
     def _compute_colors(self) -> np.ndarray:
         labels = label_hash(self, atom_labels=("atom_type", "reaction"))
         return color_refine_scrg(self, atom_labels=labels)
 
+    @override
     def _compute_hash(self) -> int:
         if self.n_atoms == 0:
             return hash(self.__class__)
         return int(numpy_int_multiset_hash(self._get_colors()))
 
+    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return NotImplemented
@@ -205,34 +193,44 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
         else:
             del self._bond_stereo_change[bond][stereo_change]
 
-    def active_atoms(self, additional_layer: int = 0) -> set[AtomId]:
+    @override
+    def active_atoms(
+        self, additional_layer: int = 0, stereo: bool = False
+    ) -> set[AtomId]:
         """
         Atoms involved in the reaction with additional layers of atoms
         in the neighborhood.
 
         :param additional_layer: Number of additional layers of atoms to
                                  include, defaults to 0
+        :param stereo: Whether to include atoms involved in stereochemistry changes
+                       defaults to False
         :return: Atoms involved in the reaction
         """
-        active_atoms: set[int] = set()
+        active_atoms: set[AtomId] = set()
 
         for bond in self.get_formed_bonds() | self.get_broken_bonds():
             active_atoms.update(bond)
-
-        for _atom, stereo_change in self.atom_stereo_changes.items():
-            for _change, stereo in stereo_change.items():
-                if stereo is not None:
-                    active_atoms.update(stereo.atoms)
-        for _bond, stereo_change in self.bond_stereo_changes.items():
-            for _change, stereo in stereo_change.items():
-                if stereo is not None:
-                    active_atoms.update(stereo.atoms)
+        if stereo:
+            for _atom, a_stereo_change in self.atom_stereo_changes.items():
+                for _change, a_stereo in a_stereo_change.items():
+                    if a_stereo is not None:
+                        for a in a_stereo.atoms:
+                            if a is not None:
+                                active_atoms.add(a)
+            for _bond, b_stereo_change in self.bond_stereo_changes.items():
+                for _change, b_stereo in b_stereo_change.items():
+                    if b_stereo is not None:
+                        for a in b_stereo.atoms:
+                            if a is not None:
+                                active_atoms.add(a)
 
         for _ in range(additional_layer):
             for atom in active_atoms.copy():
                 active_atoms.update(self.bonded_to(atom))
         return active_atoms
 
+    @override
     def copy(self, frozen: bool = False) -> Self:
         """
         :return: returns a copy of self
@@ -242,6 +240,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
         new_graph._bond_stereo_change = deepcopy(self._bond_stereo_change)
         return new_graph
 
+    @override
     def relabel_atoms(self, mapping: dict[AtomId, AtomId], copy: bool = True) -> Self:
         """
         Relabels the atoms of the graph and the chiral information accordingly
@@ -291,6 +290,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
         return relabeled_scrg
 
+    @override
     def reactant(self, keep_attributes: bool = True) -> StereoMolGraph:
         """
         Returns the reactant of the reaction
@@ -314,6 +314,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
         return reactant
 
+    @override
     def product(self, keep_attributes: bool = True) -> StereoMolGraph:
         """
         Returns the product of the reaction
@@ -335,6 +336,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
         return product
 
+    @override
     def ts(self, infer_non_fleeting_stereo: bool = True) -> StereoMolGraph:
         """Returns a StereoCondensedReactionGraph representing the transition state of
         the reaction. Stereochemistry is taken from the fleeting stereo changes if
@@ -371,6 +373,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
         return ts
 
+    @override
     def reverse_reaction(self) -> Self:
         """Creates the reaction in the opposite direction.
 
@@ -400,6 +403,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
         return rev_reac
 
+    @override
     def enantiomer(self) -> Self:
         """
         Creates the enantiomer of the StereoCondensedReactionGraph by inversion
@@ -419,62 +423,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
                 enantiomer.set_atom_stereo_change(**stereo_change_inverted)
         return enantiomer
 
-    def _to_rdmol(
-        self,
-        generate_bond_orders: bool = False,
-        allow_charged_fragments: bool = False,
-        charge: int = 0,
-    ) -> tuple[Chem.rdchem.RWMol, dict[RDKitAtomId, AtomId]]:
-        ts_smg = StereoMolGraph(self)  # bond change is now just a bond
-
-        for _atom, stereo_change_dict in self.atom_stereo_changes.items():
-            atom_stereo = next(
-                (
-                    stereo
-                    for stereo_change in (
-                        Change.FLEETING,
-                        Change.BROKEN,
-                        Change.FORMED,
-                    )
-                    if (stereo := stereo_change_dict[stereo_change]) is not None
-                ),
-                None,
-            )
-            if atom_stereo:
-                ts_smg.set_atom_stereo(atom_stereo)
-
-        for _bond, stereo_change_dict in self.bond_stereo_changes.items():
-            bond_stereo = next(
-                (
-                    stereo
-                    for stereo_change in (
-                        Change.FLEETING,
-                        Change.BROKEN,
-                        Change.FORMED,
-                    )
-                    if (stereo := stereo_change_dict[stereo_change]) is not None
-                ),
-                None,
-            )
-            if bond_stereo:
-                ts_smg.set_bond_stereo(bond_stereo)
-
-        mol, idx_map_num_dict = ts_smg._to_rdmol(
-            generate_bond_orders=False,
-            allow_charged_fragments=allow_charged_fragments,
-            charge=charge,
-        )
-        if generate_bond_orders:
-            mol = set_crg_bond_orders(
-                graph=self,
-                mol=mol,
-                generate_bond_orders=generate_bond_orders,
-                allow_charged_fragments=allow_charged_fragments,
-                charge=charge,
-                idx_map_num_dict=idx_map_num_dict,
-            )
-        return mol, idx_map_num_dict
-
+    @override
     @classmethod
     def compose(cls, mol_graphs: Iterable[MolGraph]) -> Self:
         """Creates a MolGraph object from a list of MolGraph objects
@@ -488,12 +437,13 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
             graph._bond_stereo_change.update(cls(mol_graph)._bond_stereo_change)
         return graph
 
+    @override
     @classmethod
     def from_graphs(
         cls,
-        reactant_graph: StereoMolGraph,
-        product_graph: StereoMolGraph,
-        ts_graph: None | StereoMolGraph = None,
+        reactant_graph: MolGraph,
+        product_graph: MolGraph,
+        ts_graph: None | MolGraph = None,
     ) -> Self:
         """Creates a StereoCondensedReactionGraph from reactant and product
         StereoMolGraphs.
@@ -508,11 +458,18 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
         """
 
         scrg = super().from_graphs(reactant_graph, product_graph, ts_graph)
-
+        if not isinstance(reactant_graph, StereoMolGraph) or not isinstance(
+            product_graph, StereoMolGraph
+        ):
+            return scrg
         for atom in scrg.atoms:
             r_stereo = reactant_graph.get_atom_stereo(atom)
             p_stereo = product_graph.get_atom_stereo(atom)
-            ts_stereo = ts_graph.get_atom_stereo(atom) if ts_graph else None
+            ts_stereo = (
+                ts_graph.get_atom_stereo(atom)
+                if isinstance(ts_graph, StereoMolGraph)
+                else None
+            )
 
             if ts_stereo is not None and ts_stereo == r_stereo == p_stereo:
                 scrg.set_atom_stereo(ts_stereo)
@@ -562,6 +519,7 @@ class StereoCondensedReactionGraph(StereoMolGraph, CondensedReactionGraph):
 
         return scrg
 
+    @override
     @classmethod
     def from_geometries(
         cls,

--- a/src/stereomolgraph/graphs/smg.py
+++ b/src/stereomolgraph/graphs/smg.py
@@ -6,6 +6,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, TypeVar
 
 import numpy as np
+from typing_extensions import override
 
 from stereomolgraph.algorithms.circular import (
     color_refine_smg,
@@ -14,7 +15,6 @@ from stereomolgraph.algorithms.circular import (
 )
 from stereomolgraph.algorithms.isomorphism import vf2pp_all_isomorphisms
 from stereomolgraph.coords import BondsFromDistance
-from stereomolgraph.graph2rdmol import stereo_mol_graph_to_rdmol
 from stereomolgraph.graphs.mg import AtomId, Bond, MolGraph
 from stereomolgraph.periodic_table import SYMBOLS
 from stereomolgraph.stereodescriptors import (
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from stereomolgraph.coords import GeometryProtocol
-    from stereomolgraph.graphs.mg import AtomId, RDKitAtomId
+    from stereomolgraph.graphs.mg import AtomId
 
     A = TypeVar("A", bound=tuple[int, ...], covariant=True)
     P = TypeVar("P", bound=None | Literal[1, 0, -1], covariant=True)
@@ -55,6 +55,7 @@ class StereoMolGraph(MolGraph):
 
     __hash__ = MolGraph.__hash__
 
+    @override
     def __init__(self, mol_graph: None | MolGraph = None):
         super().__init__(mol_graph)
         if mol_graph and isinstance(mol_graph, StereoMolGraph):
@@ -64,16 +65,19 @@ class StereoMolGraph(MolGraph):
             self._atom_stereo = {}
             self._bond_stereo = {}
 
+    @override
     def _compute_colors(self) -> np.ndarray:
         labels = label_hash(self, atom_labels=("atom_type",))
         return color_refine_smg(self, atom_labels=labels)
 
+    @override
     def _compute_hash(self) -> int:
         if self.n_atoms == 0:
             return hash(self.__class__)
         else:
             return int(numpy_int_multiset_hash(self._get_colors()))
 
+    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return NotImplemented
@@ -92,6 +96,7 @@ class StereoMolGraph(MolGraph):
             )
         )
 
+    @override
     def __str__(self) -> str:
         a_list = sorted(
             (a, SYMBOLS[a_type]) for a, a_type in zip(self.atoms, self.atom_types)
@@ -210,6 +215,7 @@ class StereoMolGraph(MolGraph):
         self._check_mutable()
         del self._bond_stereo[Bond(bond)]
 
+    @override
     def remove_atom(self, atom: int):
         """Removes an atom from the graph and deletes all chiral information
         associated with it
@@ -225,6 +231,7 @@ class StereoMolGraph(MolGraph):
                 self.delete_bond_stereo(bond)
         super().remove_atom(atom)
 
+    @override
     def copy(self, frozen: bool = False) -> Self:
         """
         :return: returns a copy of self
@@ -234,6 +241,7 @@ class StereoMolGraph(MolGraph):
         new_graph._bond_stereo = deepcopy(self._bond_stereo)
         return new_graph
 
+    @override
     def relabel_atoms(self, mapping: dict[int, int], copy: bool = True) -> Self:
         """
         Relabels the atoms of the graph and the chiral information accordingly
@@ -276,6 +284,7 @@ class StereoMolGraph(MolGraph):
             self._bond_stereo = new_bond_stereo_dict
             return self
 
+    @override
     def subgraph(self, atoms: Iterable[int]) -> Self:
         """Returns a subgraph of the graph with the given atoms and the chiral
         information accordingly
@@ -309,30 +318,31 @@ class StereoMolGraph(MolGraph):
                 enantiomer.set_atom_stereo(stereo.invert())
         return enantiomer
 
-    def _to_rdmol(
+    @override
+    def to_rdmol(
         self,
-        generate_bond_orders: bool = False,
+        generate_bond_orders: bool = True,
         allow_charged_fragments: bool = False,
         charge: int = 0,
-    ) -> tuple[Chem.rdchem.RWMol, dict[RDKitAtomId, AtomId]]:
-        """
-        Creates a RDKit mol object using the connectivity of the mol graph.
-        Stereochemistry is added to the mol object.
+    ) -> Chem.rdchem.Mol:
+        from stereomolgraph.graph2rdmol import stereo_mol_graph_to_rdmol
 
-        :return: RDKit molecule
-        """
-        return stereo_mol_graph_to_rdmol(
+        mol, _ = stereo_mol_graph_to_rdmol(
             self,
             generate_bond_orders=generate_bond_orders,
             allow_charged_fragments=allow_charged_fragments,
             charge=charge,
         )
+        for atom in mol.GetAtoms():  # type: ignore
+            atom.SetAtomMapNum(0, strict=True)  # type: ignore
+        return mol
 
+    @override
     @classmethod
     def from_rdmol(
         cls,
         rdmol: Chem.Mol,
-        use_atom_map_number: bool = False,
+        *,
         stereo_complete: bool = False,
         resonance: bool = True,
         lone_pair_stereo: bool = True,
@@ -344,18 +354,17 @@ class StereoMolGraph(MolGraph):
         double bonds.
 
         :param rdmol: RDKit Mol object
-        :param use_atom_map_number: If the atom map number should be used
-                                    instead of the atom index, Default: False
         :param stereo_complete: If True, we assume that the stereochemistry
                                 in the RDKit Mol is complete and all non chiral
                                 tetrahedral centers are set to an arbitrary
                                 configuration instead of None.
+        :param resonance: If True, resonance structures are considered
+        :param lone_pair_stereo: If True, lone pair stereo is considered
         :return: StereoMolGraph
         """
         from stereomolgraph.rdmol2graph import RDMol2StereoMolGraph
 
         rd2smg = RDMol2StereoMolGraph(
-            use_atom_map_number=use_atom_map_number,
             stereo_complete=stereo_complete,
             resonance=resonance,
             lone_pair_stereo=lone_pair_stereo,
@@ -363,6 +372,7 @@ class StereoMolGraph(MolGraph):
         smg = rd2smg(rdmol)
         return cls(smg)
 
+    @override
     @classmethod
     def compose(cls, mol_graphs: Iterable[MolGraph]) -> Self:
         """Creates a MolGraph object from a list of MolGraph objects.
@@ -382,6 +392,7 @@ class StereoMolGraph(MolGraph):
             graph._bond_stereo.update(cls(mol_graph)._bond_stereo)
         return graph
 
+    @override
     @classmethod
     def from_geometry_and_bond_order_matrix(
         cls: type[Self],
@@ -411,6 +422,7 @@ class StereoMolGraph(MolGraph):
         graph = stero_from_geometry(graph, geo)
         return graph
 
+    @override
     @classmethod
     def from_geometry(
         cls,
@@ -431,29 +443,3 @@ class StereoMolGraph(MolGraph):
         stereo_mol_graph = stero_from_geometry(mol_graph, geo)
         assert stereo_mol_graph is not None
         return stereo_mol_graph
-
-    def is_stereo_valid(self) -> bool:
-        """
-        Checks if the bonds required to have the defined stereochemistry
-        are present in the graph.
-
-        :return: True if the stereochemistry is valid
-        """
-        for atom, stereo in self._atom_stereo.items():
-            for neighbor in stereo.atoms[1:]:
-                if not self.has_bond(atom, neighbor):
-                    return False
-        for bond, stereo in self._bond_stereo.items():
-            if not self.has_bond(*bond):
-                return False
-            if {stereo.atoms[2], stereo.atoms[3]} != set(bond):
-                return False
-            if not self.has_bond(stereo.atoms[0], stereo.atoms[2]):
-                return False
-            if not self.has_bond(stereo.atoms[1], stereo.atoms[2]):
-                return False
-            if not self.has_bond(stereo.atoms[4], stereo.atoms[3]):
-                return False
-            if not self.has_bond(stereo.atoms[5], stereo.atoms[3]):
-                return False
-        return True

--- a/src/stereomolgraph/ipython.py
+++ b/src/stereomolgraph/ipython.py
@@ -12,7 +12,14 @@ from stereomolgraph import (
     StereoCondensedReactionGraph,
     StereoMolGraph,
 )
-from stereomolgraph.graphs.mg import AtomId, RDKitAtomId
+from stereomolgraph.graph2rdmol import (
+    RDKitAtomId,
+    condensed_reaction_graph_to_rdmol,
+    mol_graph_to_rdmol,
+    stereo_condensed_reaction_graph_to_rdmol,
+    stereo_mol_graph_to_rdmol,
+)
+from stereomolgraph.graphs.mg import AtomId
 from stereomolgraph.graphs.scrg import Change
 from stereomolgraph.stereodescriptors import PlanarBond
 
@@ -68,8 +75,18 @@ class View2D(NamedTuple):
             | StereoCondensedReactionGraph
         ),
     ) -> tuple[Chem.Mol, _HighlightTuple]:
-        mol, idx_map_num_dict = graph._to_rdmol(
-            generate_bond_orders=self.generate_bond_orders
+        match graph:
+            case StereoCondensedReactionGraph():
+                to_rdmol = stereo_condensed_reaction_graph_to_rdmol
+            case CondensedReactionGraph():
+                to_rdmol = condensed_reaction_graph_to_rdmol
+            case StereoMolGraph():
+                to_rdmol = stereo_mol_graph_to_rdmol
+            case _:
+                to_rdmol = mol_graph_to_rdmol
+        mol, idx_map_num_dict = to_rdmol(
+            graph,
+            generate_bond_orders=self.generate_bond_orders,
         )
         map_num_idx_dict: dict[AtomId, RDKitAtomId] = {
             v: k for k, v in idx_map_num_dict.items()

--- a/tests/unit/graphs/test_mg.py
+++ b/tests/unit/graphs/test_mg.py
@@ -6,6 +6,7 @@ from stereomolgraph import (
     MolGraph,
 )
 from stereomolgraph.coords import Geometry
+from stereomolgraph.graph2rdmol import mol_graph_to_rdmol
 from stereomolgraph.periodic_table import PERIODIC_TABLE as PTOE
 
 REACTION_SMILES_4007 = (
@@ -227,7 +228,7 @@ class TestMolGraph:
         )
 
     def test_to_rdmol(self, water_graph):
-        rdmol, _ = water_graph._to_rdmol()
+        rdmol, _ = mol_graph_to_rdmol(water_graph)
         assert (
             tuple([Atom.GetAtomicNum() for Atom in rdmol.GetAtoms()])
             == water_graph.atom_types

--- a/tests/unit/graphs/test_smg.py
+++ b/tests/unit/graphs/test_smg.py
@@ -6,6 +6,7 @@ from stereomolgraph import (
     Bond,
     StereoMolGraph,
 )
+from stereomolgraph.graph2rdmol import stereo_mol_graph_to_rdmol
 from stereomolgraph.periodic_table import PERIODIC_TABLE as PTOE
 from stereomolgraph.stereodescriptors import (
     AtropBond,
@@ -113,9 +114,9 @@ class TestStereoMolGraph(TestMolGraph):
         g1.set_bond_stereo(PlanarBond((0, 1, 2, 3, 4, 5), 0))
         g2.set_bond_stereo(PlanarBond((1, 0, 2, 3, 4, 5), 0))
         g3.set_bond_stereo(PlanarBond((0, 1, 2, 3, 4, 5), None))
-        rdmol_g1, idx_atom_map_dict_g1 = g1._to_rdmol()
-        rdmol_g2, idx_atom_map_dict_g2 = g2._to_rdmol()
-        rdmol_g3, idx_atom_map_dict_g3 = g3._to_rdmol()
+        rdmol_g1, idx_atom_map_dict_g1 = stereo_mol_graph_to_rdmol(g1)
+        rdmol_g2, idx_atom_map_dict_g2 = stereo_mol_graph_to_rdmol(g2)
+        rdmol_g3, idx_atom_map_dict_g3 = stereo_mol_graph_to_rdmol(g3)
 
         db1 = rdmol_g1.GetBondBetweenAtoms(2, 3)
         stereo_atoms1 = {idx_atom_map_dict_g1[i] for i in db1.GetStereoAtoms()}
@@ -145,12 +146,12 @@ class TestStereoMolGraph(TestMolGraph):
         g.add_bond(0, 4)
         g.set_atom_stereo(Tetrahedral((0, 1, 2, 3, 4), 1))
 
-        mol, _ = g._to_rdmol()
+        mol, _ = stereo_mol_graph_to_rdmol(g)
         chiral_tag = rdkit.Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CW  # type: ignore
         assert mol.GetAtomWithIdx(0).GetChiralTag() == chiral_tag
 
         g.set_atom_stereo(Tetrahedral((0, 1, 2, 3, 4), -1))
-        mol, _ = g._to_rdmol()
+        mol, _ = stereo_mol_graph_to_rdmol(g)
         chiral_tag = rdkit.Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CCW  # type: ignore
         assert mol.GetAtomWithIdx(0).GetChiralTag() == chiral_tag
 
@@ -286,9 +287,6 @@ class TestStereoMolGraph(TestMolGraph):
         assert hash(enantiomer_graph1.copy(frozen=True)) != hash(
             enantiomer_graph2.copy(frozen=True)
         )
-
-    def test_valid_stereo(self, chiral_product_graph1):
-        assert chiral_product_graph1.is_stereo_valid()
 
     def test_inchi_coords(self):
         pytest.skip("RDKit construction tests moved to test_rdkit_conversion.py")

--- a/tests/unit/test_consistency.py
+++ b/tests/unit/test_consistency.py
@@ -4,6 +4,7 @@ import rdkit.Chem.rdDistGeom  # type: ignore
 
 from stereomolgraph import StereoMolGraph
 from stereomolgraph.coords import Geometry
+from stereomolgraph.graph2rdmol import stereo_mol_graph_to_rdmol
 from stereomolgraph.rdmol2graph import RDMol2StereoMolGraph
 from stereomolgraph.stereodescriptors import (
     Octahedral,
@@ -68,7 +69,7 @@ class TestRDKitConversion:
         assert inchi == rdkit.Chem.MolToInchi(rdmol, treatWarningAsError=True)  # type: ignore
 
         smg = rdmol2graph(rdmol)
-        rdmol2, _ = smg._to_rdmol(generate_bond_orders=True)
+        rdmol2, _ = stereo_mol_graph_to_rdmol(smg, generate_bond_orders=True)
         assert inchi == rdkit.Chem.MolToInchi(rdmol2, treatWarningAsError=True)  # type: ignore
 
     @pytest.mark.parametrize(
@@ -94,7 +95,7 @@ class TestRDKitConversion:
         rdmol = rdkit.Chem.MolFromInchi(inchi)
         rdmol = rdkit.Chem.AddHs(rdmol)
         smg = rdmol2graph(rdmol)
-        rdmol2, _ = smg._to_rdmol(generate_bond_orders=True)
+        rdmol2, _ = stereo_mol_graph_to_rdmol(smg, generate_bond_orders=True)
         molblock = rdkit.Chem.MolToMolBlock(rdmol2)
         assert inchi == rdkit.Chem.MolBlockToInchi(molblock)  # type: ignore
 
@@ -145,8 +146,8 @@ class TestRDKitConversion:
         rdmol = rdkit.Chem.MolFromSmiles(smiles)
         rdmol = rdkit.Chem.AddHs(rdmol)
         smg = rdmol2graph(rdmol)
-        rdmol2, _ = smg._to_rdmol(
-            generate_bond_orders=True, allow_charged_fragments=False
+        rdmol2, _ = stereo_mol_graph_to_rdmol(
+            smg, generate_bond_orders=True, allow_charged_fragments=False
         )
         rdkit.Chem.SanitizeMol(
             rdmol2, sanitizeOps=rdkit.Chem.SanitizeFlags.SANITIZE_ALL
@@ -308,7 +309,7 @@ class TestRDKitConversion:
 
         set1 = {
             rdkit.Chem.MolToSmiles(
-                molgraph._to_rdmol()[0],
+                stereo_mol_graph_to_rdmol(molgraph)[0],
                 canonical=True,
                 ignoreAtomMapNumbers=True,
                 isomericSmiles=True,
@@ -317,7 +318,7 @@ class TestRDKitConversion:
         }
         set2 = {
             rdkit.Chem.MolToSmiles(
-                molgraph._to_rdmol()[0],
+                stereo_mol_graph_to_rdmol(molgraph)[0],
                 canonical=True,
                 ignoreAtomMapNumbers=True,
                 isomericSmiles=True,
@@ -326,7 +327,7 @@ class TestRDKitConversion:
         }
         set3 = {
             rdkit.Chem.MolToSmiles(
-                molgraph._to_rdmol()[0],
+                stereo_mol_graph_to_rdmol(molgraph)[0],
                 canonical=True,
                 ignoreAtomMapNumbers=True,
                 isomericSmiles=True,


### PR DESCRIPTION
Refactor archetecture for creation from rdkit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
- Simplified `MolGraph.from_rdmol()` and `StereoMolGraph.from_rdmol()` by removing the `use_atom_map_number` parameter.
- Enhanced `StereoCondensedReactionGraph.from_graphs()` to accept general graph types, improving flexibility.
- Removed deprecated `is_stereo_valid()` method.

**New Features**
- Added public conversion functions for condensed and stereo condensed reaction graphs to RDKit molecules, with optional bond order generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->